### PR TITLE
update pin + showpin

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -457,8 +457,17 @@ RegisterNetEvent('qb-traphouse:client:target:CloseMenu', function ()
     TriggerEvent('qb-menu:client:closeMenu')
 end)
 
-RegisterNetEvent('qb-traphouse:client:getPin', function (code)
-    Config.TrapHouses[ClosestTraphouse].pincode = code
+RegisterNetEvent('qb-traphouse:client:updatePin', function (code)
+    if ClosestTraphouse ~= nil then
+        Config.TrapHouses[ClosestTraphouse].pincode = code
+    end
+end)
+
+RegisterNetEvent('qb-traphouse:client:showPin', function ()
+    if ClosestTraphouse ~= nil then
+        TriggerServerEvent('qb-traphouse:server:updatePin', ClosestTraphouse)
+        TriggerServerEvent('qb-traphouse:server:showPin', ClosestTraphouse)
+    end
 end)
 
 
@@ -576,11 +585,11 @@ CreateThread(function ()
         wait = 500
         SetClosestTraphouse()
         if ClosestTraphouse ~= nil then
+            TriggerServerEvent('qb-traphouse:server:updatePin', ClosestTraphouse)
             if not InsideTraphouse then
                 if isInsideEntranceTarget then
                     wait = 0
                     if IsControlJustPressed(0, 38) then
-                        TriggerServerEvent('qb-traphouse:server:getPin', ClosestTraphouse)
                         TriggerEvent("qb-traphouse:client:EnterTraphouse")
                         exports['qb-core']:HideText()
                     end
@@ -625,10 +634,3 @@ CreateThread(function ()
     end
 
 end)
-
-[[-- for test command
-RegisterNetEvent('test1', function (cela)
-    local cela1 = cela
-    QBCore.Functions.Notify('tu as recu: ' .. cela1)
-end)
---]]

--- a/server/main.lua
+++ b/server/main.lua
@@ -203,9 +203,16 @@ RegisterServerEvent('qb-traphouse:server:RobNpc', function(Traphouse)
     end
 end)
 
-RegisterServerEvent('qb-traphouse:server:getPin', function(clientClosestTrapHouse)
-    local cctp = clientClosestTrapHouse
-    TriggerClientEvent('qb-traphouse:client:getPin', source, Config.TrapHouses[cctp].pincode)
+RegisterServerEvent('qb-traphouse:server:updatePin', function(clientClosestTrapHouse)
+    if clientClosestTrapHouse ~= nil then
+        TriggerClientEvent('qb-traphouse:client:updatePin', source, Config.TrapHouses[clientClosestTrapHouse].pincode)
+    end
+end)
+
+RegisterServerEvent('qb-traphouse:server:showPin', function(clientClosestTrapHouse)
+    if clientClosestTrapHouse ~= nil then
+        TriggerClientEvent('QBCore:Notify', source, 'PIN: ' .. Config.TrapHouses[clientClosestTrapHouse].pincode, 'success', 5000)
+    end
 end)
 
 -- Commands
@@ -260,21 +267,11 @@ QBCore.Commands.Add("multikeys", Lang:t("info.give_keys"), {{name = "id", help =
     end
 end)
 
+QBCore.Commands.Add("showpin", "Show nearest traphouse PIN (Admin Only)", {}, false, function(source)
+    TriggerClientEvent('qb-traphouse:client:showPin', source)
+end, 'admin')
+
 exports("AddHouseItem", AddHouseItem)
 exports("RemoveHouseItem", RemoveHouseItem)
 exports("GetInventoryData", GetInventoryData)
 exports("CanItemBeSaled", CanItemBeSaled)
-
-
-[[-- police can access pincode thru command ?
-QBCore.Commands.Add("test1", "", {}, false, function(source)
-    local src = source
-    local Player = QBCore.Functions.GetPlayer(src)
-    if Player.PlayerData.job.name == 'police' then
-        local cela = Config.TrapHouses[1].pincode
-        TriggerClientEvent('test1', src, cela)
-        alarmon = false
-    end
-end)
-
---]]


### PR DESCRIPTION
Update client PIN with server PIN before entering a traphouse 
Admin can do /showpin to see the closest traphouse PIN


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? I THINK
- Does your PR fit the contribution guidelines? I GUESS
